### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A completely rewritten version of PyOMXPlayer utilising `OMXPlayer`'s `DBus` int
 WARNING: Don't have an RPi to test this at the moment, please report an issue if this doesn't work!
 
 ```python
-from pyomxplayerng import OMXPlayer
+from omxplayer import OMXPlayer
 from time import sleep
 
 # This will start an `omxplayer` process, this might 


### PR DESCRIPTION
Proposed change following an import error, package name was changed to omxplayer from pyomxplayerng as rasied in issue here:
https://github.com/willprice/python-omxplayer/issues/1